### PR TITLE
Fixes and clean-ups for provisioning methods

### DIFF
--- a/playbooks/roles/guestfs/tasks/destroy.yml
+++ b/playbooks/roles/guestfs/tasks/destroy.yml
@@ -1,18 +1,38 @@
 ---
-- name: Destroy each target node
+- name: Gather the list of running libvirt guests
+  run_once: true
   community.libvirt.virt:
-    name: "{{ inventory_hostname }}"
-    command: "destroy"
+    command: list_vms
+    state: running
     uri: "{{ libvirt_uri }}"
-  failed_when: false # Do not fail if the target node is not currently running
+  register: running_vms
 
-- name: Undefine each target node
+- name: Shut down each running target node
   community.libvirt.virt:
     name: "{{ inventory_hostname }}"
-    command: "undefine"
+    command: destroy
     uri: "{{ libvirt_uri }}"
+  changed_when: true
+  when:
+    - inventory_hostname in running_vms.list_vms
+
+- name: Gather the list of stopped libvirt guests
+  run_once: true
+  community.libvirt.virt:
+    command: list_vms
+    state: shutdown
+    uri: "{{ libvirt_uri }}"
+  register: shutdown_vms
+
+- name: Undefine each stopped target node
+  community.libvirt.virt:
+    command: "undefine"
     force: true
-  failed_when: false # Do not fail if the target node is not currently defined
+    name: "{{ inventory_hostname }}"
+    uri: "{{ libvirt_uri }}"
+  changed_when: true
+  when:
+    - inventory_hostname in shutdown_vms.list_vms
 
 - name: Remove per-node configuration files
   ansible.builtin.file:

--- a/playbooks/roles/guestfs/tasks/install-deps/main.yml
+++ b/playbooks/roles/guestfs/tasks/install-deps/main.yml
@@ -1,7 +1,4 @@
 ---
-- name: Gathering facts
-  ansible.builtin.gather_facts:
-
 - name: Debian-specific setup
   ansible.builtin.import_tasks:
     file: debian/main.yml

--- a/playbooks/roles/guestfs/tasks/main.yml
+++ b/playbooks/roles/guestfs/tasks/main.yml
@@ -19,21 +19,21 @@
 
 - name: Set the pathname of storage pool directory
   tags:
+    - base_image
     - bringup
   ansible.builtin.set_fact:
     storagedir: "{{ kdevops_storage_pool_path }}/guestfs"
 
 - name: Set the pathname of the OS base image
   tags:
+    - base_image
     - bringup
   ansible.builtin.set_fact:
     base_image: "{{ storagedir }}/base_images/{{ virtbuilder_os_version }}.raw"
 
-- name: Ensure the base OS image exists
-  delegate_to: localhost
-  run_once: true
+- name: Ensure the required base OS image exists
   tags:
-    - bringup
+    - base_image
   ansible.builtin.import_role:
     name: base_image
   vars:

--- a/playbooks/roles/guestfs/tasks/main.yml
+++ b/playbooks/roles/guestfs/tasks/main.yml
@@ -14,12 +14,10 @@
     file: "{{role_path }}/tasks/bringup/storage-pool-path.yml"
 
 - name: Ensure libvirt networking has started
-  delegate_to: localhost
-  run_once: true
   tags:
-    - bringup
+    - network
   ansible.builtin.import_tasks:
-    file: "{{role_path }}/tasks/bringup/network.yml"
+    file: "{{ role_path }}/tasks/bringup/network.yml"
 
 - name: Set the pathname of storage pool directory
   tags:

--- a/playbooks/roles/guestfs/tasks/main.yml
+++ b/playbooks/roles/guestfs/tasks/main.yml
@@ -3,15 +3,13 @@
   tags:
     - install-deps
   ansible.builtin.import_tasks:
-    file: "{{role_path }}/tasks/install-deps/main.yml"
+    file: "{{ role_path }}/tasks/install-deps/main.yml"
 
 - name: Ensure a storage pool for guestfs exists
-  delegate_to: localhost
-  run_once: true
   tags:
-    - bringup
+    - pool
   ansible.builtin.import_tasks:
-    file: "{{role_path }}/tasks/bringup/storage-pool-path.yml"
+    file: "{{ role_path }}/tasks/bringup/storage-pool-path.yml"
 
 - name: Ensure libvirt networking has started
   tags:

--- a/playbooks/roles/guestfs/tasks/main.yml
+++ b/playbooks/roles/guestfs/tasks/main.yml
@@ -44,13 +44,11 @@
   tags:
     - bringup
   ansible.builtin.import_tasks:
-    file: "{{role_path }}/tasks/bringup/main.yml"
+    file: "{{ role_path }}/tasks/bringup/main.yml"
 
 - name: Set up target node console permissions
-  delegate_to: localhost
-  run_once: true
   tags:
-    - bringup
+    - console
   ansible.builtin.import_tasks:
     file: "{{ role_path }}/tasks/bringup/console-permissions.yml"
   when:

--- a/playbooks/terraform.yml
+++ b/playbooks/terraform.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: all
+- name: Provision target nodes with terraform
   gather_facts: false
+  hosts: all
   roles:
     - role: terraform

--- a/scripts/guestfs.Makefile
+++ b/scripts/guestfs.Makefile
@@ -79,7 +79,7 @@ bringup_guestfs: $(GUESTFS_BRINGUP_DEPS)
 		--connection=local --inventory localhost, \
 		$(KDEVOPS_PLAYBOOKS_DIR)/guestfs.yml \
 		--extra-vars=@./extra_vars.yaml \
-		--tags network
+		--tags network,pool
 	$(Q)ansible-playbook $(ANSIBLE_VERBOSE) \
 		-i hosts playbooks/guestfs.yml \
 		--extra-vars=@./extra_vars.yaml \

--- a/scripts/guestfs.Makefile
+++ b/scripts/guestfs.Makefile
@@ -84,6 +84,11 @@ bringup_guestfs: $(GUESTFS_BRINGUP_DEPS)
 		-i hosts playbooks/guestfs.yml \
 		--extra-vars=@./extra_vars.yaml \
 		--tags bringup
+	$(Q)ansible-playbook $(ANSIBLE_VERBOSE) \
+		--connection=local --inventory localhost, \
+		$(KDEVOPS_PLAYBOOKS_DIR)/guestfs.yml \
+		--extra-vars=@./extra_vars.yaml \
+		--tags console
 PHONY += bringup_guestfs
 
 status_guestfs:

--- a/scripts/guestfs.Makefile
+++ b/scripts/guestfs.Makefile
@@ -76,6 +76,11 @@ install_libguestfs:
 
 bringup_guestfs: $(GUESTFS_BRINGUP_DEPS)
 	$(Q)ansible-playbook $(ANSIBLE_VERBOSE) \
+		--connection=local --inventory localhost, \
+		$(KDEVOPS_PLAYBOOKS_DIR)/guestfs.yml \
+		--extra-vars=@./extra_vars.yaml \
+		--tags network
+	$(Q)ansible-playbook $(ANSIBLE_VERBOSE) \
 		-i hosts playbooks/guestfs.yml \
 		--extra-vars=@./extra_vars.yaml \
 		--tags bringup

--- a/scripts/guestfs.Makefile
+++ b/scripts/guestfs.Makefile
@@ -79,7 +79,7 @@ bringup_guestfs: $(GUESTFS_BRINGUP_DEPS)
 		--connection=local --inventory localhost, \
 		$(KDEVOPS_PLAYBOOKS_DIR)/guestfs.yml \
 		--extra-vars=@./extra_vars.yaml \
-		--tags network,pool
+		--tags network,pool,base_image
 	$(Q)ansible-playbook $(ANSIBLE_VERBOSE) \
 		-i hosts playbooks/guestfs.yml \
 		--extra-vars=@./extra_vars.yaml \

--- a/terraform/aws/kconfigs/distros/Kconfig.fedora
+++ b/terraform/aws/kconfigs/distros/Kconfig.fedora
@@ -17,6 +17,9 @@ config TERRAFORM_AWS_FEDORA40_X86_64
 config TERRAFORM_AWS_FEDORA41_X86_64
 	bool "Fedora 41 (x86_64)"
 
+config TERRAFORM_AWS_FEDORA42_X86_64
+	bool "Fedora 42 (x86_64)"
+
 endchoice
 
 config TERRAFORM_AWS_NS
@@ -24,6 +27,7 @@ config TERRAFORM_AWS_NS
 	output yaml
 	default "Fedora-Cloud-Base-AmazonEC2.x86_64-40-*" if TERRAFORM_AWS_FEDORA40_X86_64
 	default "Fedora-Cloud-Base-AmazonEC2.x86_64-41-*" if TERRAFORM_AWS_FEDORA41_X86_64
+	default "Fedora-Cloud-Base-AmazonEC2.x86_64-42-*" if TERRAFORM_AWS_FEDORA42_X86_64
 
 endif # TARGET_ARCH_X86_64
 
@@ -39,6 +43,9 @@ config TERRAFORM_AWS_FEDORA40_ARM64
 config TERRAFORM_AWS_FEDORA41_ARM64
 	bool "Fedora 41 (arm64"
 
+config TERRAFORM_AWS_FEDORA42_ARM64
+	bool "Fedora 42 (arm64"
+
 endchoice
 
 config TERRAFORM_AWS_NS
@@ -46,6 +53,7 @@ config TERRAFORM_AWS_NS
 	output yaml
 	default "Fedora-Cloud-Base-AmazonEC2.aarch64-40-*" if TERRAFORM_AWS_FEDORA40_ARM64
 	default "Fedora-Cloud-Base-AmazonEC2.aarch64-41-*" if TERRAFORM_AWS_FEDORA41_ARM64
+	default "Fedora-Cloud-Base-AmazonEC2.aarch64-42-*" if TERRAFORM_AWS_FEDORA42_ARM64
 
 endif # TARGET_ARCH_ARM64
 

--- a/terraform/azure/kconfigs/publishers/Kconfig.rhel
+++ b/terraform/azure/kconfigs/publishers/Kconfig.rhel
@@ -27,6 +27,12 @@ config TERRAFORM_AZURE_IMAGE_LINUX_RHEL_9_5
 	  This option sets the OS image to Red Hat Enterprise Linux
 	  release 9 update 5.
 
+config TERRAFORM_AZURE_IMAGE_LINUX_RHEL_9_6
+	bool "RHEL 9.6 x64"
+	help
+	  This option sets the OS image to Red Hat Enterprise Linux
+	  release 9 update 6.
+
 endchoice
 
 config TERRAFORM_AZURE_IMAGE_OFFER
@@ -35,6 +41,7 @@ config TERRAFORM_AZURE_IMAGE_OFFER
 	default "RHEL" if TERRAFORM_AZURE_IMAGE_LINUX_RHEL_7_9
 	default "RHEL" if TERRAFORM_AZURE_IMAGE_LINUX_RHEL_8_9
 	default "RHEL" if TERRAFORM_AZURE_IMAGE_LINUX_RHEL_9_5
+	default "RHEL" if TERRAFORM_AZURE_IMAGE_LINUX_RHEL_9_6
 
 config TERRAFORM_AZURE_IMAGE_SKU
 	string
@@ -42,6 +49,7 @@ config TERRAFORM_AZURE_IMAGE_SKU
 	default "7_9" if TERRAFORM_AZURE_IMAGE_LINUX_RHEL_7_9
 	default "8_9" if TERRAFORM_AZURE_IMAGE_LINUX_RHEL_8_9
 	default "9_5" if TERRAFORM_AZURE_IMAGE_LINUX_RHEL_9_5
+	default "9_6" if TERRAFORM_AZURE_IMAGE_LINUX_RHEL_9_6
 
 endif # TARGET_ARCH_X86_64
 


### PR DESCRIPTION
Guestfs-related changes attempt to make bringup and destroy steps faster and more reliable. Terraform-related changes introduce menu selections for Fedora 42 and RHEL 9.6, which were released recently.