### PR TITLE
playbooks: guestfs: fix import_tasks file path

### DIFF
--- a/playbooks/roles/guestfs/tasks/install-deps/main.yml
+++ b/playbooks/roles/guestfs/tasks/install-deps/main.yml
@@ -1,18 +1,18 @@
 ---
 - name: Debian-specific setup
   ansible.builtin.import_tasks:
-    file: debian/main.yml
+    file: "{{ role_path }}/tasks/install-deps/debian/main.yml"
   when:
     - ansible_os_family == "Debian"
 
 - name: SuSE-specific setup
   ansible.builtin.import_tasks:
-    file: suse/main.yml
+    file: "{{ role_path }}/tasks/install-deps/suse/main.yml"
   when:
     - ansible_os_family == "Suse"
 
 - name: Red Hat-specific setup
   ansible.builtin.import_tasks:
-    file: redhat/main.yml
+    file: "{{ role_path }}/tasks/install-deps/redhat/main.yml"
   when:
     - ansible_os_family == "Redhat"


### PR DESCRIPTION
guestfs main task YAML file import_tasks for intalling dependencies with:
  file: "{{ role_path }}/tasks/install-deps/main.yml"

That file also import_tasks using distro specific tasks. This file path needs to use the path from the role tasks/ path and not from where the file is located.

Logs:
make bringup
...
ansible-playbook -vv \
        --inventory localhost, \
        playbooks/guestfs.yml \
        --extra-vars=@./extra_vars.yaml \
        --tags install-deps
ansible-playbook [core 2.19.0b2]
  config file = /scratch/dagomez/linux-kdevops/kdevops/ansible.cfg
  configured module search path =
['/home/dagomez/.ansible/plugins/modules',
'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3/dist-packages/ansible
  ansible collection location = /home/dagomez/.ansible/collections:/usr
  /share/ansible/collections
  executable location = /usr/bin/ansible-playbook
  python version = 3.13.3 (main, Apr 10 2025, 21:38:51) [GCC 14.2.0]
(/usr/bin/python3)
  jinja version = 3.1.6
  pyyaml version = 6.0.2 (with libyaml v0.2.5)
Using /scratch/dagomez/linux-kdevops/kdevops/ansible.cfg as config file statically imported:
/scratch/dagomez/linux-kdevops/kdevops/playbooks/roles/guestfs/tasks/ install-deps/main.yml
[ERROR]: Unable to retrieve file contents.
Could not find or access
'/scratch/dagomez/linux-kdevops/kdevops/playbooks/debian/main.yml' on the Ansible Controller.
If you are using a module and expect the file to exist on the remote, see the remote_src option: [Errno 2] No such file or directory: '/scratch/dagomez/linux-kdevops/kdevops/playbooks/debian/main.yml