### PR TITLE
Fix a number of issues with kdevops' use of Google Cloud and other providers

### DIFF
--- a/kconfigs/Kconfig.ansible_cfg
+++ b/kconfigs/Kconfig.ansible_cfg
@@ -10,6 +10,10 @@ config ANSIBLE_CFG_FORKS_SET_BY_CLI
 	bool
 	default $(shell, scripts/check-cli-set-var.sh ANSIBLE_CFG_FORKS)
 
+config ANSIBLE_CFG_TASK_DEBUGGER_SET_BY_CLI
+	bool
+	default $(shell, scripts/check-cli-set-var.sh ANSIBLE_CFG_TASK_DEBUGGER)
+
 menu "Ansible Callback Plugin Configuration"
 choice
 	prompt "Ansible Callback Plugin"
@@ -206,6 +210,19 @@ config ANSIBLE_CFG_FORKS
 	default $(shell, ./scripts/append-makefile-vars-int.sh $(ANSIBLE_CFG_FORKS)) if ANSIBLE_CFG_FORKS_SET_BY_CLI
 
 endif # !ANSIBLE_CFG_FORKS_CUSTOM
+
+config ANSIBLE_CFG_TASK_DEBUGGER
+	bool "Enable the Ansible task debugger on failed tasks"
+	output yaml
+	default n
+	help
+	  When this setting is enabled, a task failure invokes the
+	  Ansible debugger. Generally this is useful only when
+	  running kdevops from the command line.
+
+	  For more information, see:
+
+	  https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_debugger.html#id10
 
 if DISTRO_OPENSUSE
 

--- a/playbooks/roles/ansible_cfg/templates/ansible.cfg.j2
+++ b/playbooks/roles/ansible_cfg/templates/ansible.cfg.j2
@@ -10,6 +10,7 @@ show_per_host_start = {{ ansible_cfg_callback_plugin_show_per_host_start }}
 show_task_path_on_failure = {{ ansible_cfg_callback_plugin_show_task_path_on_failure }}
 interpreter_python = {{ ansible_cfg_interpreter_python_string }}
 forks = {{ ansible_cfg_forks }}
+enable_task_debugger = {{ ansible_cfg_task_debugger }}
 {% if ansible_facts['distribution'] == 'openSUSE' %}
 [connection]
 retries = {{ ansible_cfg_reconnection_retries }}

--- a/playbooks/roles/codereadyrepo/tasks/main.yml
+++ b/playbooks/roles/codereadyrepo/tasks/main.yml
@@ -39,6 +39,14 @@
         - kdevops_enable_terraform
         - kdevops_terraform_provider == "azure"
 
+    - name: Select the Google Cloud RHEL CodeReady Builder repo
+      ansible.builtin.set_fact:
+        codeready_repo: "rhui-codeready-builder-for-rhel-{{ ansible_distribution_major_version }}-{{ ansible_architecture }}-rhui-rpms"
+      when:
+        - ansible_distribution == 'RedHat'
+        - kdevops_enable_terraform
+        - kdevops_terraform_provider == "gce"
+
     - name: The distribution/provisioner combo isn't recognized
       ansible.builtin.fail:
         msg: The selection heuristic failed to find a CodeReady Builder repo.

--- a/playbooks/roles/devconfig/tasks/install-deps/redhat/main.yml
+++ b/playbooks/roles/devconfig/tasks/install-deps/redhat/main.yml
@@ -32,6 +32,24 @@
     - devconfig_custom_yum_repofile
     - custom_repofile.stat.exists
 
+- name: Discover the fastest package update mirrors
+  become: true
+  become_method: ansible.builtin.sudo
+  ansible.builtin.lineinfile:
+    insertafter: "[main]"
+    line: "fastestmirror=true"
+    path: "/etc/dnf/dnf.conf"
+    state: present
+
+- name: Increase the maximum number of concurrent package downloads
+  become: true
+  become_method: ansible.builtin.sudo
+  ansible.builtin.lineinfile:
+    insertafter: "[main]"
+    line: "max_parallel_downloads=10"
+    path: "/etc/dnf/dnf.conf"
+    state: present
+
 - name: Refresh cache and upgrade all present packages
   become: yes
   become_method: sudo

--- a/terraform/aws/kconfigs/Kconfig.compute
+++ b/terraform/aws/kconfigs/Kconfig.compute
@@ -99,6 +99,9 @@ config TERRAFORM_AWS_DISTRO_DEBIAN
 config TERRAFORM_AWS_DISTRO_FEDORA
 	bool "Fedora Core"
 
+config TERRAFORM_AWS_DISTRO_OL
+	bool "Oracle Linux"
+
 config TERRAFORM_AWS_DISTRO_RHEL
 	bool "Red Hat Enterprise Linux"
 
@@ -113,6 +116,7 @@ endchoice
 source "terraform/aws/kconfigs/distros/Kconfig.amazon"
 source "terraform/aws/kconfigs/distros/Kconfig.debian"
 source "terraform/aws/kconfigs/distros/Kconfig.fedora"
+source "terraform/aws/kconfigs/distros/Kconfig.oracle"
 source "terraform/aws/kconfigs/distros/Kconfig.rhel"
 source "terraform/aws/kconfigs/distros/Kconfig.sles"
 source "terraform/aws/kconfigs/distros/Kconfig.custom"

--- a/terraform/aws/kconfigs/distros/Kconfig.oracle
+++ b/terraform/aws/kconfigs/distros/Kconfig.oracle
@@ -1,0 +1,48 @@
+if TERRAFORM_AWS_DISTRO_OL
+
+config TERRAFORM_AWS_AMI_OWNER
+	string
+	output yaml
+	default "amazon"
+
+if TARGET_ARCH_X86_64
+
+choice
+	prompt "Oracle Linux release"
+	default TERRAFORM_AWS_OL9_X86_64
+
+config TERRAFORM_AWS_OL8_X86_64
+	bool "Oracle Linux 8 (x86)"
+
+config TERRAFORM_AWS_OL9_X86_64
+	bool "Oracle Linux 9 (x86)"
+
+endchoice
+
+config TERRAFORM_AWS_NS
+	string
+	output yaml
+	default "Oracle-Linux-8.*x86_64-*" if TERRAFORM_AWS_OL8_X86_64
+	default "Oracle-Linux-9.*x86_64-*" if TERRAFORM_AWS_OL9_X86_64
+
+endif # TARGET_ARCH_X86_64
+
+if TARGET_ARCH_ARM64
+
+choice
+	prompt "Oracle Linux release"
+	default TERRAFORM_AWS_OL9_ARM64
+
+config TERRAFORM_AWS_OL9_ARM64
+	bool "Oracle Linux 9 (arm64)"
+
+endchoice
+
+config TERRAFORM_AWS_NS
+	string
+	output yaml
+	default "Oracle-Linux-9.*arm64-*" if TERRAFORM_AWS_OL9_ARM64
+
+endif # TARGET_ARCH_ARM64
+
+endif # TERRAFORM_AWS_DISTRO_OL

--- a/terraform/aws/kconfigs/distros/Kconfig.rhel
+++ b/terraform/aws/kconfigs/distros/Kconfig.rhel
@@ -11,15 +11,23 @@ choice
 	prompt "Red Hat Enterprise Linux release"
 	default TERRAFORM_AWS_RHEL9_X86_64
 
+config TERRAFORM_AWS_RHEL8_X86_64
+	bool "Red Hat Enterprise Linux 8 (x86)"
+
 config TERRAFORM_AWS_RHEL9_X86_64
 	bool "Red Hat Enterprise Linux 9 (x86)"
+
+config TERRAFORM_AWS_RHEL10_X86_64
+	bool "Red Hat Enterprise Linux 10 (x86)"
 
 endchoice
 
 config TERRAFORM_AWS_NS
 	string
 	output yaml
+	default "RHEL-8.*x86_64-*" if TERRAFORM_AWS_RHEL8_X86_64
 	default "RHEL-9.*x86_64-*" if TERRAFORM_AWS_RHEL9_X86_64
+	default "RHEL-10.*x86_64-*" if TERRAFORM_AWS_RHEL10_X86_64
 
 endif # TARGET_ARCH_X86_64
 
@@ -30,7 +38,10 @@ choice
 	default TERRAFORM_AWS_RHEL9_ARM64
 
 config TERRAFORM_AWS_RHEL9_ARM64
-	bool "RHEL9 ARM 64"
+	bool "Red Hat Enterprise Linux 9 (arm64)"
+
+config TERRAFORM_AWS_RHEL10_ARM64
+	bool "Red Hat Enterprise Linux 10 (arm64)"
 
 endchoice
 
@@ -38,6 +49,7 @@ config TERRAFORM_AWS_NS
 	string
 	output yaml
 	default "RHEL-9.*arm64-*" if TERRAFORM_AWS_RHEL9_ARM64
+	default "RHEL-10.*arm64-*" if TERRAFORM_AWS_RHEL10_ARM64
 
 endif # TARGET_ARCH_ARM64
 

--- a/terraform/gce/kconfigs/Kconfig.compute
+++ b/terraform/gce/kconfigs/Kconfig.compute
@@ -11,17 +11,35 @@ config TERRAFORM_GCE_MACHINE_FAMILY_N1_STANDARD
 	  Balanced performance and cost-effectiveness. Intel
 	  Haswell CPUs.
 
+config TERRAFORM_GCE_MACHINE_FAMILY_N2_STANDARD
+	bool "N2 Standard family"
+	depends on TARGET_ARCH_X86_64
+	help
+	  General purpose computing on Intel Cascade Lake CPUs.
+
 config TERRAFORM_GCE_MACHINE_FAMILY_N2_HIGHCPU
 	bool "N2 High CPU family"
 	depends on TARGET_ARCH_X86_64
 	help
 	  General purpose computing on Intel Cascade Lake CPUs.
 
+config TERRAFORM_GCE_MACHINE_FAMILY_N2D_STANDARD
+	bool "N2D Standard family"
+	depends on TARGET_ARCH_X86_64
+	help
+	  General purpose computing on AMD Milan CPUs.
+
 config TERRAFORM_GCE_MACHINE_FAMILY_N2D_HIGHCPU
 	bool "N2D High CPU family"
 	depends on TARGET_ARCH_X86_64
 	help
 	  General purpose computing on AMD Milan CPUs.
+
+config TERRAFORM_GCE_MACHINE_FAMILY_N4_STANDARD
+	bool "N4 Standard family"
+	depends on TARGET_ARCH_X86_64
+	help
+	  General purpose computing on Intel Emerald Rapids CPUs.
 
 config TERRAFORM_GCE_MACHINE_FAMILY_N4_HIGHCPU
 	bool "N4 High CPU family"
@@ -32,8 +50,11 @@ config TERRAFORM_GCE_MACHINE_FAMILY_N4_HIGHCPU
 endchoice
 
 source "terraform/gce/kconfigs/machines/Kconfig.n1-standard"
+source "terraform/gce/kconfigs/machines/Kconfig.n2-standard"
 source "terraform/gce/kconfigs/machines/Kconfig.n2-highcpu"
+source "terraform/gce/kconfigs/machines/Kconfig.n2d-standard"
 source "terraform/gce/kconfigs/machines/Kconfig.n2d-highcpu"
+source "terraform/gce/kconfigs/machines/Kconfig.n4-standard"
 source "terraform/gce/kconfigs/machines/Kconfig.n4-highcpu"
 
 choice

--- a/terraform/gce/kconfigs/Kconfig.compute
+++ b/terraform/gce/kconfigs/Kconfig.compute
@@ -47,6 +47,12 @@ config TERRAFORM_GCE_MACHINE_FAMILY_N4_HIGHCPU
 	help
 	  General purpose computing on Intel Emerald Rapids CPUs.
 
+config TERRAFORM_GCE_MACHINE_FAMILY_C4_STANDARD
+	bool "C4 Standard family"
+	depends on TARGET_ARCH_X86_64
+	help
+	  Consistently high performance on Intel Emerald Rapids CPUs.
+
 endchoice
 
 source "terraform/gce/kconfigs/machines/Kconfig.n1-standard"
@@ -56,6 +62,7 @@ source "terraform/gce/kconfigs/machines/Kconfig.n2d-standard"
 source "terraform/gce/kconfigs/machines/Kconfig.n2d-highcpu"
 source "terraform/gce/kconfigs/machines/Kconfig.n4-standard"
 source "terraform/gce/kconfigs/machines/Kconfig.n4-highcpu"
+source "terraform/gce/kconfigs/machines/Kconfig.c4-standard"
 
 choice
 	prompt "OS Distributor"

--- a/terraform/gce/kconfigs/Kconfig.compute
+++ b/terraform/gce/kconfigs/Kconfig.compute
@@ -52,6 +52,9 @@ config TERRAFORM_GCE_DISTRO_DEBIAN
 config TERRAFORM_GCE_DISTRO_FEDORA
 	bool "Fedora"
 
+config TERRAFORM_GCE_DISTRO_OL
+	bool "Oracle Linux"
+
 config TERRAFORM_GCE_DISTRO_OPENSUSE
 	bool "OpenSUSE"
 
@@ -69,6 +72,7 @@ endchoice
 source "terraform/gce/kconfigs/images/Kconfig.centos"
 source "terraform/gce/kconfigs/images/Kconfig.debian"
 source "terraform/gce/kconfigs/images/Kconfig.fedora"
+source "terraform/gce/kconfigs/images/Kconfig.oracle"
 source "terraform/gce/kconfigs/images/Kconfig.opensuse"
 source "terraform/gce/kconfigs/images/Kconfig.rhel"
 source "terraform/gce/kconfigs/images/Kconfig.rocky"

--- a/terraform/gce/kconfigs/images/Kconfig.oracle
+++ b/terraform/gce/kconfigs/images/Kconfig.oracle
@@ -1,0 +1,34 @@
+if TERRAFORM_GCE_DISTRO_OL
+
+config TERRAFORM_GCE_IMAGE_PROJECT
+	string
+	output yaml
+	default "oracle-linux-cloud"
+
+config TERRAFORM_GCE_IMAGE_SIZE
+	int
+	output yaml
+	default 20
+
+if TARGET_ARCH_X86_64
+
+choice
+	prompt "OS image to use"
+
+config TERRAFORM_GCE_IMAGE_OL_8_X86_64
+	bool "Oracle Linux 8 (x86)"
+
+config TERRAFORM_GCE_IMAGE_OL_9_X86_64
+	bool "Oracle Linux 9 (x86)"
+
+endchoice
+
+config TERRAFORM_GCE_IMAGE_FAMILY
+	string
+	output yaml
+	default "oracle-linux-8" if TERRAFORM_GCE_IMAGE_OL_8_X86_64
+	default "oracle-linux-9" if TERRAFORM_GCE_IMAGE_OL_9_X86_64
+
+endif # TARGET_ARCH_X86_64
+
+endif # TERRAFORM_GCE_DISTRO_OL

--- a/terraform/gce/kconfigs/machines/Kconfig.c4-standard
+++ b/terraform/gce/kconfigs/machines/Kconfig.c4-standard
@@ -1,0 +1,53 @@
+if TERRAFORM_GCE_MACHINE_FAMILY_C4_STANDARD
+
+choice
+	prompt "GCE Machine Type"
+	default TERRAFORM_GCE_MACHINE_C4_STANDARD_4
+	help
+	  This option sets the GCE machine type. For other machine
+	  types, refer to this page:
+
+	  https://cloud.google.com/compute/docs/machine-types
+
+config TERRAFORM_GCE_MACHINE_C4_STANDARD_2
+	bool "c4-standard-2"
+	help
+	  2 vCPU (1 core) and 7GB of memory.
+
+config TERRAFORM_GCE_MACHINE_C4_STANDARD_4
+	bool "c4-standard-4"
+	help
+	  4 vCPU (2 core) and 15GB of memory.
+
+config TERRAFORM_GCE_MACHINE_C4_STANDARD_8
+	bool "c4-standard-8"
+	help
+	  8 vCPU (4 cores) and 30GB of memory.
+
+config TERRAFORM_GCE_MACHINE_C4_STANDARD_16
+	bool "c4-standard-16"
+	help
+	  16 vCPU (8 cores) and 60GB of memory.
+
+config TERRAFORM_GCE_MACHINE_C4_STANDARD_24
+	bool "c4-standard-24"
+	help
+	  24 vCPU (12 cores) and 90GB of memory.
+
+endchoice
+
+config TERRAFORM_GCE_MACHINE_TYPE
+	string
+	output yaml
+	default "c4-standard-2" if TERRAFORM_GCE_MACHINE_C4_STANDARD_2
+	default "c4-standard-4" if TERRAFORM_GCE_MACHINE_C4_STANDARD_4
+	default "c4-standard-8" if TERRAFORM_GCE_MACHINE_C4_STANDARD_8
+	default "c4-standard-16" if TERRAFORM_GCE_MACHINE_C4_STANDARD_16
+	default "c4-standard-24" if TERRAFORM_GCE_MACHINE_C4_STANDARD_24
+
+config TERRAFORM_GCE_IMAGE_TYPE
+	string
+	output yaml
+	default "hyperdisk-balanced"
+
+endif # TERRAFORM_GCE_MACHINE_FAMILY_C4_STANDARD

--- a/terraform/gce/kconfigs/machines/Kconfig.n2-standard
+++ b/terraform/gce/kconfigs/machines/Kconfig.n2-standard
@@ -1,0 +1,58 @@
+if TERRAFORM_GCE_MACHINE_FAMILY_N2_STANDARD
+
+choice
+	prompt "GCE Machine type"
+	default TERRAFORM_GCE_MACHINE_N2_STANDARD_8
+	help
+	  This option sets the GCE machine type. For other machine
+	  types, refer to this page:
+
+	  https://cloud.google.com/compute/docs/machine-types
+
+config TERRAFORM_GCE_MACHINE_N2_STANDARD_2
+	bool "n2-standard-2"
+	depends on TARGET_ARCH_X86_64
+	help
+	  2 vCPU (1 core) and 8GB of memory.
+
+config TERRAFORM_GCE_MACHINE_N2_STANDARD_4
+	bool "n2-standard-4"
+	depends on TARGET_ARCH_X86_64
+	help
+	  4 vCPU (2 core) and 16GB of memory.
+
+config TERRAFORM_GCE_MACHINE_N2_STANDARD_8
+	bool "n2-standard-8"
+	depends on TARGET_ARCH_X86_64
+	help
+	  8 vCPU (4 cores) and 32GB of memory.
+
+config TERRAFORM_GCE_MACHINE_N2_STANDARD_16
+	bool "n2-standard-16"
+	depends on TARGET_ARCH_X86_64
+	help
+	  16 vCPU (8 cores) and 64GB of memory.
+
+config TERRAFORM_GCE_MACHINE_N2_STANDARD_32
+	bool "n2-standard-32"
+	depends on TARGET_ARCH_X86_64
+	help
+	  32 vCPU (16 cores) and 128GB of memory.
+
+endchoice
+
+config TERRAFORM_GCE_MACHINE_TYPE
+	string
+	output yaml
+	default "n2-standard-2" if TERRAFORM_GCE_MACHINE_N2_STANDARD_2
+	default "n2-standard-4" if TERRAFORM_GCE_MACHINE_N2_STANDARD_4
+	default "n2-standard-8" if TERRAFORM_GCE_MACHINE_N2_STANDARD_8
+	default "n2-standard-16" if TERRAFORM_GCE_MACHINE_N2_STANDARD_16
+	default "n2-standard-32" if TERRAFORM_GCE_MACHINE_N2_STANDARD_32
+
+config TERRAFORM_GCE_IMAGE_TYPE
+	string
+	output yaml
+	default "pd-balanced"
+
+endif # TERRAFORM_GCE_MACHINE_FAMILY_N2_STANDARD

--- a/terraform/gce/kconfigs/machines/Kconfig.n2d-standard
+++ b/terraform/gce/kconfigs/machines/Kconfig.n2d-standard
@@ -1,0 +1,58 @@
+if TERRAFORM_GCE_MACHINE_FAMILY_N2D_STANDARD
+
+choice
+	prompt "GCE Machine type"
+	default TERRAFORM_GCE_MACHINE_N2D_STANDARD_4
+	help
+	  This option sets the GCE machine type. For other machine
+	  types, refer to this page:
+
+	  https://cloud.google.com/compute/docs/machine-types
+
+config TERRAFORM_GCE_MACHINE_N2D_STANDARD_2
+	bool "n2d-standard-2"
+	depends on TARGET_ARCH_X86_64
+	help
+	  2 vCPU (1 core) and 8GB of memory.
+
+config TERRAFORM_GCE_MACHINE_N2D_STANDARD_4
+	bool "n2d-standard-4"
+	depends on TARGET_ARCH_X86_64
+	help
+	  4 vCPU (2 core) and 16GB of memory.
+
+config TERRAFORM_GCE_MACHINE_N2D_STANDARD_8
+	bool "n2d-standard-8"
+	depends on TARGET_ARCH_X86_64
+	help
+	  8 vCPU (4 cores) and 32GB of memory.
+
+config TERRAFORM_GCE_MACHINE_N2D_STANDARD_16
+	bool "n2d-standard-16"
+	depends on TARGET_ARCH_X86_64
+	help
+	  16 vCPU (8 cores) and 64GB of memory.
+
+config TERRAFORM_GCE_MACHINE_N2D_STANDARD_32
+	bool "n2d-standard-32"
+	depends on TARGET_ARCH_X86_64
+	help
+	  32 vCPU (16 cores) and 128GB of memory.
+
+endchoice
+
+config TERRAFORM_GCE_MACHINE_TYPE
+	string
+	output yaml
+	default "n2d-standard-2" if TERRAFORM_GCE_MACHINE_N2D_STANDARD_2
+	default "n2d-standard-4" if TERRAFORM_GCE_MACHINE_N2D_STANDARD_4
+	default "n2d-standard-8" if TERRAFORM_GCE_MACHINE_N2D_STANDARD_8
+	default "n2d-standard-16" if TERRAFORM_GCE_MACHINE_N2D_STANDARD_16
+	default "n2d-standard-32" if TERRAFORM_GCE_MACHINE_N2D_STANDARD_32
+
+config TERRAFORM_GCE_IMAGE_TYPE
+	string
+	output yaml
+	default "pd-balanced"
+
+endif # TERRAFORM_GCE_MACHINE_FAMILY_N2D_STANDARD

--- a/terraform/gce/kconfigs/machines/Kconfig.n4-standard
+++ b/terraform/gce/kconfigs/machines/Kconfig.n4-standard
@@ -1,0 +1,53 @@
+if TERRAFORM_GCE_MACHINE_FAMILY_N4_STANDARD
+
+choice
+	prompt "GCE Machine Type"
+	default TERRAFORM_GCE_MACHINE_N4_STANDARD_4
+	help
+	  This option sets the GCE machine type. For other machine
+	  types, refer to this page:
+
+	  https://cloud.google.com/compute/docs/machine-types
+
+config TERRAFORM_GCE_MACHINE_N4_STANDARD_2
+	bool "n4-standard-2"
+	help
+	  2 vCPU (1 core) and 8GB of memory.
+
+config TERRAFORM_GCE_MACHINE_N4_STANDARD_4
+	bool "n4-standard-4"
+	help
+	  4 vCPU (2 core) and 16GB of memory.
+
+config TERRAFORM_GCE_MACHINE_N4_STANDARD_8
+	bool "n4-standard-8"
+	help
+	  8 vCPU (4 cores) and 32GB of memory.
+
+config TERRAFORM_GCE_MACHINE_N4_STANDARD_16
+	bool "n4-standard-16"
+	help
+	  16 vCPU (8 cores) and 64GB of memory.
+
+config TERRAFORM_GCE_MACHINE_N4_STANDARD_32
+	bool "n4-standard-32"
+	help
+	  32 vCPU (16 cores) and 128GB of memory.
+
+endchoice
+
+config TERRAFORM_GCE_MACHINE_TYPE
+	string
+	output yaml
+	default "n4-standard-2" if TERRAFORM_GCE_MACHINE_N4_STANDARD_2
+	default "n4-standard-4" if TERRAFORM_GCE_MACHINE_N4_STANDARD_4
+	default "n4-standard-8" if TERRAFORM_GCE_MACHINE_N4_STANDARD_8
+	default "n4-standard-16" if TERRAFORM_GCE_MACHINE_N4_STANDARD_16
+	default "n4-standard-32" if TERRAFORM_GCE_MACHINE_N4_STANDARD_32
+
+config TERRAFORM_GCE_IMAGE_TYPE
+	string
+	output yaml
+	default "hyperdisk-balanced"
+
+endif # TERRAFORM_GCE_MACHINE_FAMILY_N4_STANDARD

--- a/terraform/gce/kconfigs/zones/Kconfig.northamerica-south1
+++ b/terraform/gce/kconfigs/zones/Kconfig.northamerica-south1
@@ -7,21 +7,21 @@ choice
 	  A zone is a deployment area within a region.
 
 config TERRAFORM_GCE_REGION_NORTHAMERICA_SOUTH1_A
-	bool "northamerica-northeast1-a"
+	bool "northamerica-south1-a"
 
 config TERRAFORM_GCE_REGION_NORTHAMERICA_SOUTH1_B
-	bool "northamerica-northeast1-b"
+	bool "northamerica-south1-b"
 
 config TERRAFORM_GCE_REGION_NORTHAMERICA_SOUTH1_C
-	bool "northamerica-northeast1-c"
+	bool "northamerica-south1-c"
 
 endchoice
 
 config TERRAFORM_GCE_ZONE
 	string
 	output yaml
-	default "northamerica-northeast1-a" if TERRAFORM_GCE_REGION_NORTHAMERICA_SOUTH1_A
-	default "northamerica-northeast1-b" if TERRAFORM_GCE_REGION_NORTHAMERICA_SOUTH1_B
-	default "northamerica-northeast1-c" if TERRAFORM_GCE_REGION_NORTHAMERICA_SOUTH1_C
+	default "northamerica-south1-a" if TERRAFORM_GCE_REGION_NORTHAMERICA_SOUTH1_A
+	default "northamerica-south1-b" if TERRAFORM_GCE_REGION_NORTHAMERICA_SOUTH1_B
+	default "northamerica-south1-c" if TERRAFORM_GCE_REGION_NORTHAMERICA_SOUTH1_C
 
 endif # TERRAFORM_GCE_REGION_NORTHAMERICA_SOUTH1

--- a/terraform/oci/kconfigs/images/Kconfig.OracleLinux
+++ b/terraform/oci/kconfigs/images/Kconfig.OracleLinux
@@ -88,6 +88,33 @@ config TERRAFORM_OCI_OPERATING_SYSTEM_ORACLE_LINUX_9_5_X86
 	  Image release notes:
 	  https://docs.oracle.com/en-us/iaas/images/oracle-linux-9x/oracle-linux-9-5-2025-03-18-0.htm
 
+config TERRAFORM_OCI_OPERATING_SYSTEM_ORACLE_LINUX_9_6_GPU
+	bool "Oracle Linux 9.6 Gen2 GPU"
+	depends on TARGET_ARCH_X86_64
+	help
+	  Oracle-Linux-9.6-Gen2-GPU-2025.06.17-0
+
+	  Image release notes:
+	  https://docs.oracle.com/en-us/iaas/images/oracle-linux-9x/oracle-linux-9-6-gen2-gpu-2025-06-17-0.htm
+
+config TERRAFORM_OCI_OPERATING_SYSTEM_ORACLE_LINUX_9_6_ARM64
+	bool "Oracle Linux 9.6 (aarch64)"
+	depends on TARGET_ARCH_ARM64
+	help
+	  Oracle-Linux-9.6-aarch64-2025.06.17-0
+
+	  Image release notes:
+	  https://docs.oracle.com/en-us/iaas/images/oracle-linux-9x/oracle-linux-9-6-aarch64-2025-06-17-0.htm
+
+config TERRAFORM_OCI_OPERATING_SYSTEM_ORACLE_LINUX_9_6_X86
+	bool "Oracle Linux 9.6 (x86)"
+	depends on TARGET_ARCH_X86_64
+	help
+	  Oracle-Linux-9.6-2025.06.17-0
+
+	  Image release notes:
+	  https://docs.oracle.com/en-us/iaas/images/oracle-linux-9x/oracle-linux-9-6-2025-06-17-0.htm
+
 endchoice
 
 if TERRAFORM_OCI_OPERATING_SYSTEM_ORACLE_LINUX_7_9_X86
@@ -233,5 +260,53 @@ config TERRAFORM_OCI_OS_IMAGE_OCID
 	default "ocid1.image.oc1.us-sanjose-1.aaaaaaaaopxntceb4zygnto7tbi7ezxptoxp3m72jz5ttpp5zfg4iklupr4q" if TERRAFORM_OCI_REGION_SJC
 
 endif # TERRAFORM_OCI_OPERATING_SYSTEM_ORACLE_LINUX_9_5_X86
+
+if TERRAFORM_OCI_OPERATING_SYSTEM_ORACLE_LINUX_9_6_GPU
+
+config TERRAFORM_OCI_OS_IMAGE_OCID
+	string
+	output yaml
+	default "ocid1.image.oc1.us-chicago-1.aaaaaaaaxetvxo7pwc2uoj7gel5yyrroofgm6wgito7g6lvu4rcyzjetlmta" if TERRAFORM_OCI_REGION_ORD
+	default "ocid1.image.oc1.ap-mumbai-1.aaaaaaaaju6ud4bzvkwzphlaw4tt27mx374t4eoq36vufk6qavpwc2imis7a" if TERRAFORM_OCI_REGION_BOM
+	default "ocid1.image.oc1.phx.aaaaaaaaxtx5e3vilq727xx2f32ad72l46gt2tvanlqfoi7mkrbae4zafeea" if TERRAFORM_OCI_REGION_PHX
+	default "ocid1.image.oc1.ap-hyderabad-1.aaaaaaaayfjxrv3z5quvwn4sbwxalxct6ic67otjvjgub2rdh5b3rsugbqya" if TERRAFORM_OCI_REGION_HYD
+	default "ocid1.image.oc1.ca-toronto-1.aaaaaaaa6amxhb4uxcyjnztvyjmvwo2cv3aencrpwo2ltqf5g4fjt4iddmuq" if TERRAFORM_OCI_REGION_YYZ
+	default "ocid1.image.oc1.ca-montreal-1.aaaaaaaaowpmyyvgx232gettpqyeb5vxyfhaapcwuftqczcisyfprbnwyqsa" if TERRAFORM_OCI_REGION_YUL
+	default "ocid1.image.oc1.iad.aaaaaaaa6lrr64teb63cmprsnmlozagcmcmqedg6ubjsij7vszptipgzpedq" if TERRAFORM_OCI_REGION_IAD
+	default "ocid1.image.oc1.us-sanjose-1.aaaaaaaab77uhcrbou4iqji3qah6ync663l6inyjqnwa66q4suscxtdb3aya" if TERRAFORM_OCI_REGION_SJC
+
+endif # TERRAFORM_OCI_OPERATING_SYSTEM_ORACLE_LINUX_9_6_GPU
+
+if TERRAFORM_OCI_OPERATING_SYSTEM_ORACLE_LINUX_9_6_ARM64
+
+config TERRAFORM_OCI_OS_IMAGE_OCID
+	string
+	output yaml
+	default "ocid1.image.oc1.us-chicago-1.aaaaaaaarth4ajbp464qwkcwfmzqkzmgamnuiuot354oe437quz7dt47g2gq" if TERRAFORM_OCI_REGION_ORD
+	default "ocid1.image.oc1.ap-mumbai-1.aaaaaaaa4ly37lnuij6u5irxnqxvcy7pi2mhmioc7o6jwm6sudex5rtqatda" if TERRAFORM_OCI_REGION_BOM
+	default "ocid1.image.oc1.phx.aaaaaaaaaawp4x63fjccfs2cwdq63ofvftcktl56xp2afophsp4xvemr52ba" if TERRAFORM_OCI_REGION_PHX
+	default "ocid1.image.oc1.ap-hyderabad-1.aaaaaaaa76hls27mlpe5ietuukxidsc5czy3332z5vjoys5nc7gp74fhtena" if TERRAFORM_OCI_REGION_HYD
+	default "ocid1.image.oc1.ca-toronto-1.aaaaaaaamh6uuodtwvl2n2vijgrzfn4qgnud4cikdveeeoqbuulecvv6z5fa" if TERRAFORM_OCI_REGION_YYZ
+	default "ocid1.image.oc1.ca-montreal-1.aaaaaaaaqtbcyvi5blheqy4ryj5zy4xbgab4gg5lu4ryfdezipxwrzn7xzca" if TERRAFORM_OCI_REGION_YUL
+	default "ocid1.image.oc1.iad.aaaaaaaayh2t6irbplharxvcfcpzopxl5ojk3gm3jtthnonhvd4pupliie5a" if TERRAFORM_OCI_REGION_IAD
+	default "ocid1.image.oc1.us-sanjose-1.aaaaaaaa3gmh6j33rmb2z5vd52lb6dyvn6iy24kryhvhqe546rwtbbypzltq" if TERRAFORM_OCI_REGION_SJC
+
+endif # TERRAFORM_OCI_OPERATING_SYSTEM_ORACLE_LINUX_9_6_ARM64
+
+if TERRAFORM_OCI_OPERATING_SYSTEM_ORACLE_LINUX_9_6_X86
+
+config TERRAFORM_OCI_OS_IMAGE_OCID
+	string
+	output yaml
+	default "ocid1.image.oc1.us-chicago-1.aaaaaaaaxglgurk3cbsfgzrknz6bm4745br6sflp73pymuhu7nu3bg324goa" if TERRAFORM_OCI_REGION_ORD
+	default "ocid1.image.oc1.ap-mumbai-1.aaaaaaaafigfhiva5nurwfo2yjp2mfvzcjdhqxbclxp2mvtm4kk44qnu5lra" if TERRAFORM_OCI_REGION_BOM
+	default "ocid1.image.oc1.phx.aaaaaaaanoh2ncjgaee7kxlkkeify2hux7nqcrfn4fjacruqupzlm6572zwa" if TERRAFORM_OCI_REGION_PHX
+	default "ocid1.image.oc1.ap-hyderabad-1.aaaaaaaanobby7pyz667w7mupftxwfa67sz5rpb3cm3eecgjq5sxpmxg5moq" if TERRAFORM_OCI_REGION_HYD
+	default "ocid1.image.oc1.ca-toronto-1.aaaaaaaakdieboyxlwwrs5mbbshzl3or3xh4vgn7n2gve5pfdkvgtcwdiopq" if TERRAFORM_OCI_REGION_YYZ
+	default "ocid1.image.oc1.ca-montreal-1.aaaaaaaahagfoemyqlfb5mwp3umst7h7tbzetf3eoehz5lvm3mdtofkgeuta" if TERRAFORM_OCI_REGION_YUL
+	default "ocid1.image.oc1.iad.aaaaaaaafjz2wgkvdamf3epnseff5aybkefqpqmbx5ol6xklszeatspdwswa" if TERRAFORM_OCI_REGION_IAD
+	default "ocid1.image.oc1.us-sanjose-1.aaaaaaaaztvaby7stzck64mwfze6rosjs53dlg4umqxz3p4h3dqavo2zhirq" if TERRAFORM_OCI_REGION_SJC
+
+endif # TERRAFORM_OCI_OPERATING_SYSTEM_ORACLE_LINUX_9_6_X86
 
 endif # TERRAFORM_OCI_OPERATING_SYSTEM_ORACLE_LINUX


### PR DESCRIPTION
- Fix incorrect region information (copy-paste)
- Grab the correct CodeReady Builder repo on Google Cloud
- Add Oracle Linux and RHEL 9 update 6
- Add more GCE machine type choices