### PR TITLE
blktests: fix diy output in oscheck run task

### DIFF
--- a/playbooks/roles/blktests/tasks/main.yml
+++ b/playbooks/roles/blktests/tasks/main.yml
@@ -364,9 +364,9 @@
 
 - name: Run blktests using oscheck.sh
   vars:
-    group: "{{ ansible_host | regex_replace('blktests-') | regex_replace(kdevops_host_prefix + '-') | regex_replace('-dev') | regex_replace('-', '_') }}"
+    group: "{{ inventory_hostname | regex_replace('blktests-') | regex_replace(kdevops_host_prefix + '-') | regex_replace('-dev') | regex_replace('-', '_') }}"
     ansible_callback_diy_runner_on_ok_msg: |
-      $ {{ ansible_callback_diy.result.output.cmd | join(' ') }}
+      $ {{ ansible_callback_diy.task.args._raw_params | default('command') }}
       {{ ansible_callback_diy.result.output.stdout | default('') }}
   tags: ["blktests", "run_tests"]
   become: true


### PR DESCRIPTION
The diy callback plugin was throwing warnings about undefined 'cmd' attribute because the template attempted to access command information through ansible_callback_diy.result.output.cmd, which doesn't exist for ansible.builtin.command modules.

Fixed by using ansible_callback_diy.task.args._raw_params to access the actual command being executed, and replaced ansible_host with inventory_hostname for proper variable scope in the callback context.

Debugging with the following vars helped finding the root cause:

ansible_callback_diy_runner_on_ok_msg: |
  DEBUG - Result keys: {{ ansible_callback_diy.result.output.keys() | list }}
  DEBUG - Task args: {{ ansible_callback_diy.task.args }}
  DEBUG - Direct keys: {{ ansible_callback_diy.keys() | list }}
  $ {{ ansible_callback_diy.task.args._raw_params | default('command') }}
  {{ stdout | default('') }}

Output:

TASK: Run blktests using oscheck.sh [dgc-testing-block,dgc-testing-nvme] DEBUG - Result keys: ['changed', '_ansible_no_log', 'censored'] DEBUG - Task args: {'chdir': '/usr/local/blktests/', '_raw_params':
    './oscheck.sh --print-start --print-done --test-group block  block/003'}
DEBUG - Direct keys: ['playbook', 'play', 'task', 'result', 'top_level_var_names'] $ ./oscheck.sh --print-start --print-done --test-group block  block/003 DEBUG - Result keys: ['changed', '_ansible_no_log', 'censored'] DEBUG - Task args: {'chdir': '/usr/local/blktests/', '_raw_params': './oscheck.sh --print-start --print-done --test-group nvme  block/003'} DEBUG - Direct keys: ['playbook', 'play', 'task', 'result', 'top_level_var_names'] $ ./oscheck.sh --print-start --print-done --test-group nvme  block/003

Generated-by: Claude AI