### PR TITLE
Makefile: terraform wasn't building the kdevops_nodes file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,15 +144,15 @@ endif
 DEFAULT_DEPS += $(ANSIBLE_CFG_FILE)
 DEFAULT_DEPS += $(ANSIBLE_INVENTORY_FILE)
 
-ifneq (,$(KDEVOPS_NODES))
-DEFAULT_DEPS += $(KDEVOPS_NODES)
-endif
-
 include scripts/provision.Makefile
 include scripts/firstconfig.Makefile
 include scripts/systemd-timesync.Makefile
 include scripts/journal-server.Makefile
 include scripts/update_etc_hosts.Makefile
+
+ifneq (,$(KDEVOPS_NODES))
+DEFAULT_DEPS += $(KDEVOPS_NODES)
+endif
 
 KDEVOPS_BRING_UP_DEPS += $(KDEVOPS_BRING_UP_DEPS_EARLY)
 KDEVOPS_BRING_UP_DEPS += $(KDEVOPS_PROVISIONED_DEVCONFIG)


### PR DESCRIPTION
When "make bringup" runs "terraform plan", it complains that the kdevops_nodes variable isn't set.

extra_vars.yaml does contain the variable, but I'm guessing that somehow gen_nodes runs after gen_tfvars now? Not really sure.

Daniel suggests:
> I think it'd be best to move KDEVOPS_NODES just after we assign
> the filename to it (provision.Makefile -> guestfs.Makefile):

Fixes: 5457b742d611 ("Makefile: fix target dependency order")