### PR TITLE
Fixes for kernel-builder with Debian 11

### DIFF
--- a/playbooks/roles/bootlinux/defaults/main.yml
+++ b/playbooks/roles/bootlinux/defaults/main.yml
@@ -141,9 +141,3 @@ bootlinux_fragment_x86: false
 bootlinux_fragment_xarray: false
 bootlinux_fragment_xarray_no_multi: false
 
-
-# Distro controls
-distro_debian_based: false
-distro_fedora: false
-distro_redhat_based: false
-distro_suse_based: false

--- a/playbooks/roles/bootlinux/tasks/build/9p.yml
+++ b/playbooks/roles/bootlinux/tasks/build/9p.yml
@@ -14,7 +14,7 @@
   when:
     - target_linux_install_b4 is defined
     - target_linux_install_b4
-    - not distro_debian_based|bool
+    - ansible_facts['os_family']|lower != 'debian'
   run_once: true
   delegate_to: localhost
 

--- a/playbooks/roles/bootlinux/tasks/build/builder.yml
+++ b/playbooks/roles/bootlinux/tasks/build/builder.yml
@@ -176,6 +176,11 @@
   when:
     - ansible_os_family == "Debian"
   block:
+    - name: Build the list of artifacts directories on the builder
+      ansible.builtin.set_fact:
+        artifact_paths:
+          - "{{ target_linux_dir_path }}/.."
+
     - name: Make the bindeb-pkg target
       community.general.make:
         chdir: "{{ target_linux_dir_path }}"

--- a/playbooks/roles/bootlinux/tasks/install-deps/debian/main.yml
+++ b/playbooks/roles/bootlinux/tasks/install-deps/debian/main.yml
@@ -40,4 +40,7 @@
       - libncurses-dev
       - b4
       - ccache
+      - rsync
+      - dwarves
+      - lz4
     state: present

--- a/playbooks/roles/bootlinux/tasks/install-deps/main.yml
+++ b/playbooks/roles/bootlinux/tasks/install-deps/main.yml
@@ -2,14 +2,14 @@
 - name: Debian-specific setup
   ansible.builtin.import_tasks: debian/main.yml
   when:
-    - distro_debian_based|bool
+    - ansible_os_family == "Debian"
 
 - name: SuSE-specific setup
   ansible.builtin.import_tasks: suse/main.yml
   when:
-    - distro_suse_based|bool
+    - ansible_os_family == "Suse"
 
 - name: Red Hat-specific setup
   ansible.builtin.import_tasks: redhat/main.yml
   when:
-    - distro_redhat_based|bool
+    - ansible_os_family == "RedHat"

--- a/playbooks/roles/bootlinux/tasks/install-deps/redhat/main.yml
+++ b/playbooks/roles/bootlinux/tasks/install-deps/redhat/main.yml
@@ -3,7 +3,7 @@
   ansible.builtin.include_role:
     name: epel-release
   when:
-    - not distro_fedora|bool
+    - ansible_distribution != "Fedora"
 
 - name: Install packages we care about
   become: true
@@ -67,7 +67,7 @@
   vars:
     packages:
       - btrfs-progs
-  when: distro_fedora|bool
+  when: ansible_distribution == 'Fedora'
 
 - name: Install clang
   become: true

--- a/playbooks/roles/bootlinux/tasks/install/packages.yml
+++ b/playbooks/roles/bootlinux/tasks/install/packages.yml
@@ -39,3 +39,45 @@
       loop: "{{ kernel_packages }}"
       loop_control:
         label: "Installing {{ item }}"
+      changed_when: true
+
+- name: Install the built kernel debs on the target nodes
+  when:
+    - ansible_os_family == "Debian"
+  block:
+    - name: Find the kernel build artifacts on the control host
+      delegate_to: localhost
+      ansible.builtin.find:
+        paths: "{{ bootlinux_artifacts_dir }}"
+        patterns: "*.deb"
+        file_type: file
+        recurse: true
+      register: found_debs
+
+    - name: Upload the kernel build artifacts to the target nodes
+      ansible.builtin.copy:
+        src: "{{ item.path }}"
+        dest: "/tmp"
+        mode: "u=rw,g=r,o=r"
+      loop: "{{ found_debs.files }}"
+      loop_control:
+        label: "Uploading {{ item.path | basename }} ..."
+
+    - name: Add the core kernel package
+      ansible.builtin.set_fact:
+        kernel_packages: "{{ kernel_packages + ['/tmp/' + item.path | basename] }}"
+      when:
+        - "'headers' not in item.path"
+      loop: "{{ found_debs.files }}"
+      loop_control:
+        label: "Adding {{ item.path | basename }} ..."
+
+    - name: Install the selected kernel build artifacts on the target nodes
+      become: true
+      become_method: ansible.builtin.sudo
+      ansible.builtin.command:
+        cmd: "dpkg -i {{ item }}"
+      loop: "{{ kernel_packages }}"
+      loop_control:
+        label: "Installing {{ item }}"
+      changed_when: true

--- a/playbooks/roles/bootlinux/tasks/update-grub/install.yml
+++ b/playbooks/roles/bootlinux/tasks/update-grub/install.yml
@@ -212,3 +212,66 @@
       when:
         - kernel_release_file.stat.exists
 
+    # GRUB detection logic for packaged kernels on Debian
+    - name: Construct the command line to determine the default boot entry (package)
+      tags:
+        - saved
+      ansible.builtin.set_fact:
+        determine_default_kernel_id: >-
+          awk -F\' '/menuentry / {print $2}' /boot/grub/grub.cfg |
+          awk '{print NR-1" ... "$0}' |
+          grep {{ kernelrelease }} |
+          head -1 |
+          awk '{print $1}'
+      when:
+        - kernel_release_file.stat.exists
+        - kernelrelease is defined
+        - kernelrelease != "unknown"
+        - ansible_facts['os_family']|lower == 'debian'
+
+    - name: Determine the target kernel's GRUB boot entry number (package)  # noqa: command-instead-of-shell
+      tags:
+        - saved
+      become: true
+      become_flags: "su - -c"
+      become_method: ansible.builtin.sudo
+      ansible.builtin.shell:
+        cmd: "{{ determine_default_kernel_id }}"
+      register: grub_boot_number_cmd
+      changed_when: false
+      when:
+        - kernel_release_file.stat.exists
+        - kernelrelease is defined
+        - kernelrelease != "unknown"
+        - determine_default_kernel_id is defined
+
+    - name: Set the target kernel to be booted by default (package)
+      become: true
+      become_flags: "su - -c"
+      become_method: ansible.builtin.sudo
+      ansible.builtin.command:
+        cmd: "/usr/sbin/grub-set-default \"{{ grub_boot_number_cmd.stdout_lines.0 }}\""
+      changed_when: true
+      tags: ["saved"]
+      when:
+        - grub_boot_number_cmd is defined
+        - grub_boot_number_cmd.rc is defined
+        - grub_boot_number_cmd.rc == 0
+        - grub_boot_number_cmd.stdout is defined
+        - grub_boot_number_cmd.stdout != ""
+
+    - name: Itemize kernel and GRUB entry selected (package)
+      ansible.builtin.debug:
+        msg: >-
+          {{ target_kernel }} determined to be {{ grub_boot_number_cmd.stdout_lines.0 }}
+          on the GRUB2 flat menu.
+          Ran: grub-set-default {{ grub_boot_number_cmd.stdout_lines.0 }}
+      vars:
+        target_kernel: "{{ kernelrelease }}"
+      tags: ["saved"]
+      when:
+        - grub_boot_number_cmd is defined
+        - grub_boot_number_cmd.rc is defined
+        - grub_boot_number_cmd.rc == 0
+        - grub_boot_number_cmd.stdout is defined
+        - grub_boot_number_cmd.stdout != ""

--- a/playbooks/roles/pynfs/tasks/install-deps/debian/main.yml
+++ b/playbooks/roles/pynfs/tasks/install-deps/debian/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Install pynfs build dependencies
   become: true
-  become_method: sudo
+  become_method: ansible.builtin.sudo
   ansible.builtin.apt:
     name:
       - gcc
@@ -13,7 +13,18 @@
       - swig
       - python3-gssapi
       - python3-ply
-      - python3-standard-xdrlib
     state: present
     update_cache: true
   tags: ["pynfs", "deps"]
+
+# xdrlib was removed from Python 3.13; Debian packages it as python3-mda-xdrlib
+- name: Install xdrlib from Debian package on Debian 13+
+  become: true
+  become_method: ansible.builtin.sudo
+  ansible.builtin.apt:
+    name:
+      - python3-mda-xdrlib
+    state: present
+  tags: ["pynfs", "deps"]
+  when:
+    - ansible_distribution_major_version | int >= 13

--- a/workflows/linux/Makefile
+++ b/workflows/linux/Makefile
@@ -69,6 +69,16 @@ endif
 BOOTLINUX_ARGS += bootlinux_cxl_test=$(CONFIG_ENABLE_CXL_TEST)
 WORKFLOW_ARGS += $(BOOTLINUX_ARGS)
 
+# Default host limit for bootlinux operations
+BOOTLINUX_LIMIT := baseline:dev
+
+# When NFS server is enabled, include it in kernel updates so that workflows
+# like fstests, gitr, nfstest, and pynfs can test the kernel's NFS server
+# implementation (knfsd).
+ifeq (y,$(CONFIG_KDEVOPS_SETUP_NFSD))
+BOOTLINUX_LIMIT := baseline:dev:nfsd
+endif
+
 PHONY +=  linux-help-menu
 linux-help-menu:
 	@echo "Linux git kernel development options"
@@ -102,14 +112,14 @@ linux: linux-baseline linux-dev
 else
 linux: $(KDEVOPS_NODES)
 	$(Q)ansible-playbook $(ANSIBLE_VERBOSE) \
-		--limit 'baseline:dev' \
+		--limit '$(BOOTLINUX_LIMIT)' \
 		$(KDEVOPS_PLAYBOOKS_DIR)/bootlinux.yml \
 		--extra-vars="$(BOOTLINUX_ARGS)" $(LIMIT_HOSTS)
 endif
 else
 linux: $(KDEVOPS_NODES)
 	$(Q)ansible-playbook $(ANSIBLE_VERBOSE) \
-		--limit 'baseline:dev' \
+		--limit '$(BOOTLINUX_LIMIT)' \
 		$(KDEVOPS_PLAYBOOKS_DIR)/bootlinux.yml \
 		--extra-vars="$(BOOTLINUX_ARGS)" $(LIMIT_HOSTS)
 endif
@@ -143,7 +153,7 @@ endif
 PHONY += linux-mount
 linux-mount:
 	$(Q)ansible-playbook $(ANSIBLE_VERBOSE) \
-		--limit 'baseline:dev' \
+		--limit '$(BOOTLINUX_LIMIT)' \
 		$(KDEVOPS_PLAYBOOKS_DIR)/bootlinux.yml \
 		--tags vars,9p_mount \
 		--extra-vars="$(BOOTLINUX_ARGS)" $(LIMIT_HOSTS)
@@ -151,7 +161,7 @@ linux-mount:
 PHONY += linux-deploy
 linux-deploy:
 	$(Q)ansible-playbook $(ANSIBLE_VERBOSE) \
-		--limit 'baseline:dev' \
+		--limit '$(BOOTLINUX_LIMIT)' \
 		$(KDEVOPS_PLAYBOOKS_DIR)/bootlinux.yml \
 		--tags vars,build-linux,install-linux,manual-update-grub,saved,vars,reboot \
 		--extra-vars="$(BOOTLINUX_ARGS)" $(LIMIT_HOSTS)
@@ -159,7 +169,7 @@ linux-deploy:
 PHONY += linux-build
 linux-build:
 	$(Q)ansible-playbook $(ANSIBLE_VERBOSE) \
-		--limit 'baseline:dev' \
+		--limit '$(BOOTLINUX_LIMIT)' \
 		$(KDEVOPS_PLAYBOOKS_DIR)/bootlinux.yml \
 		--tags vars,build-linux,saved,vars \
 		--extra-vars="$(BOOTLINUX_ARGS)" $(LIMIT_HOSTS)
@@ -167,7 +177,7 @@ linux-build:
 PHONY += linux-install
 linux-install:
 	$(Q)ansible-playbook $(ANSIBLE_VERBOSE) \
-		--limit 'baseline:dev' \
+		--limit '$(BOOTLINUX_LIMIT)' \
 		$(KDEVOPS_PLAYBOOKS_DIR)/bootlinux.yml \
 		--tags vars,build-linux,install-linux \
 		--extra-vars="$(BOOTLINUX_ARGS)" $(LIMIT_HOSTS)
@@ -175,7 +185,7 @@ linux-install:
 PHONY += linux-uninstall
 linux-uninstall:
 	$(Q)ansible-playbook $(ANSIBLE_VERBOSE) \
-		--limit 'baseline:dev' \
+		--limit '$(BOOTLINUX_LIMIT)' \
 		$(KDEVOPS_PLAYBOOKS_DIR)/bootlinux.yml \
 		--tags uninstall-linux,vars \
 		--extra-vars '{ "uninstall_kernel_enable": "True", $(LINUX_DYNAMIC_RUNTIME_VARS) }' \
@@ -183,7 +193,7 @@ linux-uninstall:
 
 linux-clone-clients: $(KDEVOPS_NODES)
 	$(Q)ansible-playbook $(ANSIBLE_VERBOSE) \
-		--limit 'baseline:dev' \
+		--limit '$(BOOTLINUX_LIMIT)' \
 		$(KDEVOPS_PLAYBOOKS_DIR)/bootlinux.yml \
 		--extra-vars="$(BOOTLINUX_ARGS)" $(LIMIT_HOSTS) \
 		--tags vars,clone
@@ -202,20 +212,20 @@ linux-clone: $(KDEVOPS_NODES) $(LINUX_CLONE_DEFAULT_TYPE)
 PHONY += linux-grub-setup
 linux-grub-setup:
 	$(Q)ansible-playbook $(ANSIBLE_VERBOSE) \
-		--limit 'baseline:dev' \
+		--limit '$(BOOTLINUX_LIMIT)' \
 		$(KDEVOPS_PLAYBOOKS_DIR)/bootlinux.yml \
 		--extra-vars="$(BOOTLINUX_ARGS)" $(LIMIT_HOSTS) --tags manual-update-grub,saved,vars
 
 PHONY += linux-reboot
 linux-reboot:
 	$(Q)ansible-playbook $(ANSIBLE_VERBOSE) \
-		--limit 'baseline:dev' \
+		--limit '$(BOOTLINUX_LIMIT)' \
 		$(KDEVOPS_PLAYBOOKS_DIR)/bootlinux.yml \
 		--extra-vars="$(BOOTLINUX_ARGS)" $(LIMIT_HOSTS) --tags vars,reboot
 
 PHONY += uname
 uname:
-	$(Q)ansible 'baseline:dev' -b -m command -a "uname -r" -o \
+	$(Q)ansible '$(BOOTLINUX_LIMIT)' -b -m command -a "uname -r" -o \
 	| awk -F '|' '{gsub(/^ +| +$$/, "", $$2); printf "%-30s %s\n", $$1, $$4}' \
 	| sed -e 's|(stdout)||'
 
@@ -223,7 +233,7 @@ ifeq (y,$(CONFIG_KDEVOPS_WORKFLOW_ENABLE_CXL))
 PHONY += linux-cxl
 linux-cxl: $(KDEVOPS_NODES)
 	$(Q)ansible-playbook $(ANSIBLE_VERBOSE) \
-		--limit 'baseline:dev' \
+		--limit '$(BOOTLINUX_LIMIT)' \
 		$(KDEVOPS_PLAYBOOKS_DIR)/bootlinux.yml \
 		--tags 'vars,cxl-build,cxl-install'                             \
 		--extra-vars="$(BOOTLINUX_ARGS)" $(LIMIT_HOSTS)


### PR DESCRIPTION
I finally have a need to use Debian instead of a Red Hat-based OS on my test runners. This means that the bootlinux_builder implementation I did for RHEL/Fedora needs to be completed so that Debian works too. This series does that and throws in a few fixes for running NFS-related workflows on Debian 11.